### PR TITLE
Поддержка новых payload'ов для графовых сущностей

### DIFF
--- a/app/schemas/graph.py
+++ b/app/schemas/graph.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 NODE_TYPES = {"api", "event", "service", "ui", "store", "task"}
 NODE_STATUSES = {"active", "archived"}
@@ -11,14 +11,54 @@ EDGE_TYPES = {"uses", "produces", "consumes", "depends"}
 
 
 class NodeBase(BaseModel):
-    label: str
-    node_type: str = Field(default="service")
+    label: str = Field(validation_alias=AliasChoices("label", "name"))
+    node_type: str = Field(default="service", validation_alias=AliasChoices("node_type", "nodeType"))
     status: str = Field(default="active")
     summary: Optional[str] = None
     position: Dict[str, float]
     metadata: Dict[str, Any] = Field(default_factory=dict)
     links: List[str] = Field(default_factory=list)
     owners: List[str] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def apply_archived_flag(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        archived_value: Any = None
+        if "archived" in data:
+            archived_value = data.pop("archived")
+        elif "is_archived" in data:
+            archived_value = data.pop("is_archived")
+        elif "isArchived" in data:
+            archived_value = data.pop("isArchived")
+
+        if archived_value is None:
+            return data
+
+        archived_bool: Optional[bool]
+        if isinstance(archived_value, bool):
+            archived_bool = archived_value
+        elif isinstance(archived_value, (int, float)):
+            archived_bool = bool(archived_value)
+        elif isinstance(archived_value, str):
+            lowered = archived_value.strip().lower()
+            if lowered in {"true", "1", "yes", "on"}:
+                archived_bool = True
+            elif lowered in {"false", "0", "no", "off", ""}:
+                archived_bool = False
+            else:
+                raise ValueError("invalid archived flag")
+        else:
+            raise ValueError("invalid archived flag")
+
+        derived_status = "archived" if archived_bool else "active"
+        existing_status = data.get("status")
+        if existing_status is not None and existing_status != derived_status:
+            raise ValueError("conflicting archived flag and status")
+        data["status"] = derived_status
+        return data
 
     @field_validator("node_type")
     @classmethod
@@ -55,18 +95,57 @@ class NodeBase(BaseModel):
 
 
 class NodeCreate(NodeBase):
-    sphere_id: int
+    sphere_id: int = Field(validation_alias=AliasChoices("sphere_id", "sphereId"))
 
 
 class NodeUpdate(BaseModel):
-    label: Optional[str] = None
-    node_type: Optional[str] = None
+    label: Optional[str] = Field(default=None, validation_alias=AliasChoices("label", "name"))
+    node_type: Optional[str] = Field(default=None, validation_alias=AliasChoices("node_type", "nodeType"))
     status: Optional[str] = None
     summary: Optional[str] = None
     position: Optional[Dict[str, float]] = None
     metadata: Optional[Dict[str, Any]] = None
     links: Optional[List[str]] = None
     owners: Optional[List[str]] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def apply_archived_flag(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        archived_value: Any = None
+        if "archived" in data:
+            archived_value = data.pop("archived")
+        elif "is_archived" in data:
+            archived_value = data.pop("is_archived")
+        elif "isArchived" in data:
+            archived_value = data.pop("isArchived")
+
+        if archived_value is None:
+            return data
+
+        if isinstance(archived_value, bool):
+            archived_bool = archived_value
+        elif isinstance(archived_value, (int, float)):
+            archived_bool = bool(archived_value)
+        elif isinstance(archived_value, str):
+            lowered = archived_value.strip().lower()
+            if lowered in {"true", "1", "yes", "on"}:
+                archived_bool = True
+            elif lowered in {"false", "0", "no", "off", ""}:
+                archived_bool = False
+            else:
+                raise ValueError("invalid archived flag")
+        else:
+            raise ValueError("invalid archived flag")
+
+        derived_status = "archived" if archived_bool else "active"
+        existing_status = data.get("status")
+        if existing_status is not None and existing_status != derived_status:
+            raise ValueError("conflicting archived flag and status")
+        data["status"] = derived_status
+        return data
 
     @field_validator("node_type")
     @classmethod
@@ -82,6 +161,24 @@ class NodeUpdate(BaseModel):
             raise ValueError("invalid node status")
         return value
 
+    @field_validator("links", mode="before")
+    @classmethod
+    def split_links(cls, value: List[str] | str | None) -> Optional[List[str]]:
+        if value is None:
+            return value
+        if isinstance(value, str):
+            return [part.strip() for part in value.split(",") if part.strip()]
+        return [item.strip() for item in value]
+
+    @field_validator("owners", mode="before")
+    @classmethod
+    def split_owners(cls, value: List[str] | str | None) -> Optional[List[str]]:
+        if value is None:
+            return value
+        if isinstance(value, str):
+            return [part.strip() for part in value.split(",") if part.strip()]
+        return [item.strip() for item in value]
+
 
 class NodeRead(NodeBase):
     id: int
@@ -95,10 +192,10 @@ class NodeRead(NodeBase):
 
 
 class EdgeBase(BaseModel):
-    sphere_id: int
-    source_node_id: int
-    target_node_id: int
-    relation_type: str = Field(default="depends")
+    sphere_id: int = Field(validation_alias=AliasChoices("sphere_id", "sphereId"))
+    source_node_id: int = Field(validation_alias=AliasChoices("source_node_id", "sourceNodeId"))
+    target_node_id: int = Field(validation_alias=AliasChoices("target_node_id", "targetNodeId"))
+    relation_type: str = Field(default="depends", validation_alias=AliasChoices("relation_type", "relationType"))
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("relation_type")
@@ -114,7 +211,9 @@ class EdgeCreate(EdgeBase):
 
 
 class EdgeUpdate(BaseModel):
-    relation_type: Optional[str] = None
+    relation_type: Optional[str] = Field(
+        default=None, validation_alias=AliasChoices("relation_type", "relationType")
+    )
     metadata: Optional[Dict[str, Any]] = None
 
     @field_validator("relation_type")

--- a/app/schemas/organization.py
+++ b/app/schemas/organization.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from app.models.organization import OrganizationRole
 
@@ -52,7 +52,9 @@ class GroupBase(BaseModel):
 
 
 class GroupCreate(GroupBase):
-    organization_id: int
+    organization_id: int = Field(
+        validation_alias=AliasChoices("organization_id", "organizationId")
+    )
 
 
 class GroupUpdate(BaseModel):
@@ -83,27 +85,63 @@ class GroupRead(GroupBase):
 
 
 class SphereBase(BaseModel):
-    name: str
+    name: str = Field(validation_alias=AliasChoices("name", "label"))
     description: Optional[str] = None
     color: Optional[str] = None
-    center_x: Optional[float] = Field(default=None, ge=0.0, le=1.0)
-    center_y: Optional[float] = Field(default=None, ge=0.0, le=1.0)
-    radius: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    center_x: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("center_x", "centerX"),
+    )
+    center_y: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("center_y", "centerY"),
+    )
+    radius: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("radius", "sphereRadius"),
+    )
 
 
 class SphereCreate(SphereBase):
-    organization_id: int
-    group_ids: List[int] = Field(default_factory=list)
+    organization_id: int = Field(
+        validation_alias=AliasChoices("organization_id", "organizationId")
+    )
+    group_ids: List[int] = Field(
+        default_factory=list, validation_alias=AliasChoices("group_ids", "groupIds")
+    )
 
 
 class SphereUpdate(BaseModel):
-    name: Optional[str] = None
+    name: Optional[str] = Field(default=None, validation_alias=AliasChoices("name", "label"))
     description: Optional[str] = None
     color: Optional[str] = None
-    center_x: Optional[float] = Field(default=None, ge=0.0, le=1.0)
-    center_y: Optional[float] = Field(default=None, ge=0.0, le=1.0)
-    radius: Optional[float] = Field(default=None, ge=0.0, le=1.0)
-    group_ids: Optional[List[int]] = None
+    center_x: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("center_x", "centerX"),
+    )
+    center_y: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("center_y", "centerY"),
+    )
+    radius: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("radius", "sphereRadius"),
+    )
+    group_ids: Optional[List[int]] = Field(
+        default=None, validation_alias=AliasChoices("group_ids", "groupIds")
+    )
 
 
 class SphereRead(SphereBase):
@@ -116,14 +154,31 @@ class SphereRead(SphereBase):
 
 
 class SphereLayoutItem(BaseModel):
-    sphere_id: int
-    center_x: Optional[float] = Field(default=None, ge=0.0, le=1.0)
-    center_y: Optional[float] = Field(default=None, ge=0.0, le=1.0)
-    radius: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    sphere_id: int = Field(validation_alias=AliasChoices("sphere_id", "sphereId"))
+    center_x: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("center_x", "centerX"),
+    )
+    center_y: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("center_y", "centerY"),
+    )
+    radius: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("radius", "sphereRadius"),
+    )
 
 
 class SphereLayoutRequest(BaseModel):
-    organization_id: int
+    organization_id: int = Field(
+        validation_alias=AliasChoices("organization_id", "organizationId")
+    )
     layout: List[SphereLayoutItem]
 
 


### PR DESCRIPTION
## Описание
- добавил alias и валидацию для новых полей в схемах сфер, узлов и ребер
- синхронизировал статус узла с булевым флагом archived и поддержал строковые списки при обновлении
- расширил тесты графа проверками camelCase payload'ов и создания сферы через API

## Тестирование
- pytest
