### PR TITLE
Унификация запуска карты и нормализация данных графа

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<section class="workspace" data-controller="org-dashboard">
+<section class="workspace" data-controller="org-dashboard" data-egida-entry="org-dashboard">
   <aside class="sidebar">
     <header class="sidebar-header">
       <h1>{{ project_name }}</h1>


### PR DESCRIPTION
## Summary
- добавлены вспомогательные адаптеры для узлов, рёбер и сфер перед построением Cytoscape, чтобы работать с фактическими полями API
- унифицирована инициализация OrgDashboard через единый бутстраппер с поддержкой htmx-загрузок и повторного старта
- обновлён шаблон дашборда с явной точкой входа data-egida-entry

## Testing
- pytest