### PR TITLE
Fix modal overlay hidden state

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -483,6 +483,11 @@ button.link:hover {
   z-index: 10;
 }
 
+.modal-overlay[hidden] {
+  display: none !important;
+  pointer-events: none;
+}
+
 .modal {
   background: rgba(8, 22, 35, 0.95);
   border: 1px solid rgba(148, 163, 184, 0.28);


### PR DESCRIPTION
## Summary
- убедитесь, что модальные наложения удалены из потока взаимодействия, когда они скрыты, чтобы кнопки закрытия снова заработали

## Testing
- pytest