### PR TITLE
Persist dashboard credentials for map actions

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -458,6 +458,10 @@ button.link:hover {
   z-index: 6;
 }
 
+.fab-menu[hidden] {
+  display: none !important;
+}
+
 .fab-menu button {
   background: transparent;
   border: none;
@@ -481,6 +485,11 @@ button.link:hover {
   justify-content: center;
   padding: 2rem;
   z-index: 10;
+}
+
+.modal-overlay[hidden] {
+  display: none !important;
+  pointer-events: none;
 }
 
 .modal {


### PR DESCRIPTION
## Summary
- persist the organization dashboard token and organization id in local storage and hydrate the form on init
- require a valid auth context before creating spheres, nodes, or edges and reuse stored credentials for API calls
- hide the floating action menu whenever the hidden attribute is present

## Testing
- pytest